### PR TITLE
fix profile image update for connected accounts

### DIFF
--- a/lib/Service/ProviderService.php
+++ b/lib/Service/ProviderService.php
@@ -436,7 +436,7 @@ class ProviderService
                 $curl = new Curl();
                 try {
                     $photo = $curl->request($profile->photoURL);
-                    $avatar = $this->avatarManager->getAvatar($uid);
+                    $avatar = $this->avatarManager->getAvatar($user->getUid());
                     $avatar->set($photo);
                 } catch (\Exception $e) {}
             }


### PR DESCRIPTION
For connected accounts the `$uid` variable may not point to user's uid, so profile image update fails.
Taking the `$user->getUid()` function instead solves the issue for us.